### PR TITLE
(feat): Implement conn.reset() - fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var check = require('./lib/check')
 var getOk = require('./lib/get-ok')
 var on = require('./lib/on')
 var off = require('./lib/off')
+var reset = require('./lib/reset')
 
 var parseOptions = require('./lib/utils/parse-options')
 var getCache = require('./lib/utils/cache').get
@@ -35,6 +36,7 @@ function Connection (options) {
     },
     check: check.bind(null, state),
     on: on.bind(null, state),
-    off: off.bind(null, state)
+    off: off.bind(null, state),
+    reset: reset.bind(null, state)
   }
 }

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -1,0 +1,11 @@
+module.exports = reset
+
+var Promise = require('lie')
+var cache = require('./utils/cache')
+
+function reset (state) {
+  state.timestamp = undefined
+  state.error = undefined
+  cache.set(state)
+  return Promise.resolve()
+}

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -1,3 +1,4 @@
 require('./instance')
 require('./cache')
 require('./walkthrough')
+require('./reset')

--- a/tests/integration/reset.js
+++ b/tests/integration/reset.js
@@ -1,0 +1,79 @@
+var store = require('humble-localstorage')
+var test = require('tape')
+
+var ConnectionStatus = require('../../index')
+
+test('connection.reset() resets the state', function (t) {
+  t.plan(2)
+
+  store.setObject('connection_https://example.com/ping', {
+    timestamp: new Date()
+  })
+
+  var connectionStatus = new ConnectionStatus({
+    url: 'https://example.com/ping'
+  })
+
+  t.is(connectionStatus.ok, true, 'connection status is connected')
+
+  connectionStatus.reset().then(function () {
+    t.is(connectionStatus.ok, undefined, 'connection status is disconnected')
+  }).catch(function (err) {
+    t.fail(err)
+  })
+})
+
+test('connection.reset() resets the timestamp', function (t) {
+  t.plan(3)
+
+  store.setObject('connection_https://example.com/ping', {
+    timestamp: new Date()
+  })
+
+  var connectionStatus = new ConnectionStatus({
+    url: 'https://example.com/ping'
+  })
+
+  t.is(connectionStatus.ok, true, 'connection status is connected')
+
+  connectionStatus.reset().then(function () {
+    t.is(connectionStatus.ok, undefined, 'connection status is disconnected')
+
+    store.setObject('connection_https://example.com/ping', {
+      timestamp: new Date()
+    })
+    connectionStatus = new ConnectionStatus({
+      url: 'https://example.com/ping'
+    })
+
+    t.is(connectionStatus.ok, true, 'connection status is reconnected')
+  }).catch(function (err) {
+    t.fail(err)
+  })
+})
+
+test('connection.reset() resets any errors', function (t) {
+  t.plan(2)
+
+  store.setObject('connection_https://example.com/ping', {
+    error: new Error('no soup for you')
+  })
+
+  var connectionStatus = new ConnectionStatus({
+    url: 'https://example.com/ping'
+  })
+
+  t.is(connectionStatus.ok, undefined, 'connection status is in error')
+  connectionStatus.reset().then(function () {
+    store.setObject('connection_https://example.com/ping', {
+      timestamp: new Date()
+    })
+    connectionStatus = new ConnectionStatus({
+      url: 'https://example.com/ping'
+    })
+
+    t.is(connectionStatus.ok, true, 'connection status is fine now')
+  }).catch(function (err) {
+    t.fail(err)
+  })
+})


### PR DESCRIPTION
This only implements reset() itself, without support
for options. Supporting options are a TODO.