### PR TITLE
Rename 'disconnected' and 'reconnected' events

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ https://github.com/hoodiehq/hoodie-client/issues/6
 ```js
 var connectionStatus = new ConnectionStatus('https://example.com/ping')
 
-connectionStatus.on('disconnected', showOfflineNotification)
-connectionStatus.on('reconnected reset', hideOfflineNotification)
+connectionStatus.on('disconnect', showOfflineNotification)
+connectionStatus.on('reconnect reset', hideOfflineNotification)
 
 myOtherRemoteApiThing.on('error', connectionStatus.check)
 ```
@@ -51,7 +51,7 @@ Example
 ```js
 var connectionStatus = new ConnectionStatus('https://example.com/ping')
 
-connectionStatus.on('disconnected', showOfflineNotification)
+connectionStatus.on('disconnect', showOfflineNotification)
 connectionStatus.check()
 ```
 
@@ -109,9 +109,9 @@ connectionStatus.reset(options).then(function () {
 
 ### Events
 
-- 'disconnected'  
+- 'disconnect'  
   Triggered if ping failed and `connectionStatus.ok` isn’t `false`
-- 'reconnected'  
+- 'reconnect'  
   Triggered if ping succeeded and `connectionStatus.ok` is `false`
 - 'reset'  
   Triggered if `connectionStatus.reset()` called, or cache invalidated
@@ -119,8 +119,8 @@ connectionStatus.reset(options).then(function () {
 Example
 
 ```js
-connectionStatus.on('disconnected', handler)
-connectionStatus.on('reconnected', handler)
+connectionStatus.on('disconnect', handler)
+connectionStatus.on('reconnect', handler)
 connectionStatus.on('reset', handler)
 ```
 

--- a/lib/check.js
+++ b/lib/check.js
@@ -33,7 +33,7 @@ function check (state, options) {
       }
 
       if (state.error) {
-        state.emitter.emit('reconnected')
+        state.emitter.emit('reconnect')
         delete state.error
       }
 
@@ -55,7 +55,7 @@ function parse (options) {
 
 function handleError (state, error, options) {
   if (!state.error) {
-    state.emitter.emit('disconnected')
+    state.emitter.emit('disconnect')
   }
   state.error = error
   internals.cache.set(state, error)

--- a/tests/unit/check.js
+++ b/tests/unit/check.js
@@ -56,8 +56,8 @@ test('check() with 500 response', function (t) {
   })
 
   var emitter = new EventEmitter()
-  emitter.on('disconnected', function () {
-    t.pass('"disconnected" event emitted')
+  emitter.on('disconnect', function () {
+    t.pass('"disconnect" event emitted')
   })
 
   var state = {
@@ -182,8 +182,8 @@ test('check() with 200 response when state.error is set', function (t) {
   simple.mock(check.internals.cache, 'set').callFn(function () {})
   simple.mock(check.internals, 'nets').callbackWith(null, {})
   var emitter = new EventEmitter()
-  emitter.on('reconnected', function () {
-    t.pass('"reconnected" event emitted')
+  emitter.on('reconnect', function () {
+    t.pass('"reconnect" event emitted')
   })
 
   var state = {


### PR DESCRIPTION
Updates the `disconnected` and `reconnected` event names to `disconnect` and `reconnect`

Fixes #14 